### PR TITLE
Update python_version for 3.13

### DIFF
--- a/anyrun.json
+++ b/anyrun.json
@@ -7,7 +7,7 @@
     "logo": "logo_anyrun.svg",
     "logo_dark": "logo_anyrun_dark.svg",
     "product_name": "ANY.RUN",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "product_version_regex": ".*",
     "publisher": "ANYRUN FZCO",
     "license": "Copyright (c) ANYRUN FZCO, 2025",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -7,4 +7,4 @@
 * Improved error handling and validation in the Configuration class
 * Optimized reputation lookups for better performance
 * Updated type annotations throughout the codebase for better code quality
-* Updated dependencies to the latest versions 
+* Updated dependencies to the latest versions * Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)